### PR TITLE
feat: create DynamoDB table for storing data

### DIFF
--- a/infrastructure/bin/app.ts
+++ b/infrastructure/bin/app.ts
@@ -2,7 +2,9 @@
 import { App } from 'aws-cdk-lib';
 import { S3Stack } from '../lib/s3-stack';
 import { LambdaStack } from '../lib/lambda-stack';
+import { DynamoDBStack } from '../lib/dynamodb-stack';
 
 const app = new App();
 const s3Stack = new S3Stack(app, 'S3Stack');
+const dynamoDBStack = new DynamoDBStack(app, 'DynamoDBStack');
 new LambdaStack(app, 'LambdaStack', s3Stack.bucket);

--- a/infrastructure/lib/dynamodb-stack.ts
+++ b/infrastructure/lib/dynamodb-stack.ts
@@ -1,0 +1,38 @@
+import {
+  Stack,
+  StackProps,
+  aws_dynamodb as dynamodb,
+  RemovalPolicy,
+} from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+
+export class DynamoDBStack extends Stack {
+  public readonly fileTable: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
+
+    this.fileTable = new dynamodb.Table(this, 'FileTable', {
+      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+    });
+
+    this.fileTable.addGlobalSecondaryIndex({
+      indexName: 'inputFilePathIndex',
+      partitionKey: {
+        name: 'input_file_path',
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
+    this.fileTable.addGlobalSecondaryIndex({
+      indexName: 'outputFilePathIndex',
+      partitionKey: {
+        name: 'output_file_path',
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
+    this.fileTable.applyRemovalPolicy(RemovalPolicy.DESTROY);
+  }
+}


### PR DESCRIPTION
- Add `DynamoDBStack` (`dynamodb-stack.ts`) to define the DynamoDB table
- Configure DynamoDB table with partition key `id` of type `STRING`
- Set billing mode to `PAY_PER_REQUEST` for cost optimization
- Apply removal policy to `DESTROY` for easy cleanup
- Add global secondary indexes for querying by `input_file_path` and `output_file_path`
- Update `app.ts` to include `DynamoDBStack` in the CDK app