### PR TITLE
feat: implement script logic on EC2 instance

### DIFF
--- a/fullstack-project/scripts/process_file.sh
+++ b/fullstack-project/scripts/process_file.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Retrieve input data from DynamoDB
+input_text=$(aws dynamodb get-item --table-name FileTable --key '{"id": {"S": "'"$1"'"}}' --query 'Item.input_text.S' --output text)
+input_file_path=$(aws dynamodb get-item --table-name FileTable --key '{"id": {"S": "'"$1"'"}}' --query 'Item.input_file_path.S' --output text)
+
+# Download input file from S3
+aws s3 cp "$input_file_path" input_file.txt
+
+# Append input text to the downloaded file
+echo "$input_text" >> input_file.txt
+
+# Upload output file to S3
+output_file_path="s3://${S3_BUCKET}/output/${1}.txt"
+aws s3 cp input_file.txt "$output_file_path"
+
+# Update DynamoDB table with output file path
+aws dynamodb update-item --table-name FileTable --key '{"id": {"S": "'"$1"'"}}' --update-expression 'SET output_file_path = :path' --expression-attribute-values '{":path": {"S": "'"$output_file_path"'"}}'


### PR DESCRIPTION
This commit introduces the script execution logic on the EC2 instance to process the input file, upload the output file to S3, and update the DynamoDB table with the output file path.

Key changes:

- Create a new script file `process_file.sh` in the `scripts` directory.

- Implement the script logic to retrieve input data from DynamoDB, download the input file from S3, append the input text to the file, upload the output file to S3, and update the DynamoDB table with the output file path.

- Update the `EC2Stack` in `lib/ec2-stack.ts` to configure the EC2 instance with the necessary permissions and script.

- Read the `process_file.sh` script and add it to the EC2 instance's user data to be executed during instance launch.

- Assign an IAM role to the EC2 instance with the required permissions to access S3 and DynamoDB.

With these changes, the EC2 instance will execute the `process_file.sh` script when it is launched. The script will process the input file, generate the output file, and update the corresponding entries in S3 and DynamoDB.